### PR TITLE
Including PYD artifacts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,13 @@ py-modules = ["pqcrypto"]
 pure-python = false
 ignore-vcs = true
 include = ["pqcrypto"]
-exclude = ["pqcrypto/**/*.c", "pqcrypto/**/*.o", "Release", "Release/**"]
+exclude = ["pqcrypto/**/*.c", "pqcrypto/**/*.o", "Release"]
+artifacts = [
+    "pqcrypto/_kem/*.so",
+    "pqcrypto/_kem/*.pyd",
+    "pqcrypto/_sign/*.so",
+    "pqcrypto/_sign/*.pyd"
+]
 
 [tool.hatch.build.hooks.custom]
 path = "build.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pqcrypto"
-version = "0.3.2"
+version = "0.3.3"
 description = "Post-quantum cryptography for Python."
 authors = [{ name = "Backbone Authors", email = "root@backbone.dev" }]
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -300,7 +300,7 @@ wheels = [
 
 [[package]]
 name = "pqcrypto"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
This PR defines `*.pyd` and `*.so` files as artifacts to be included in the wheel to resolve the issue identified in #14.

## Context:
Issue #14 found that windows pqcrypto wheels were defective.
PR #15 attempted to fix this by finding and moving the _kem and _sign directories to the correct locations as part of the compilation script. This didn't solve the issue as it included `.obj` files rather than `.pyd` files resulting in exceptions when importing compiled binaries.